### PR TITLE
Prohibit to build query only string

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,0 @@
-github: Hazealign

--- a/edgegraph/expressions/base.py
+++ b/edgegraph/expressions/base.py
@@ -1,6 +1,8 @@
 import abc
 import typing as t
 
+from edgegraph.types import QueryResult
+
 T = t.TypeVar("T")
 
 
@@ -8,5 +10,5 @@ class Expression(t.Generic[T], metaclass=abc.ABCMeta):
     base_cls: t.Type[T]
 
     @abc.abstractmethod
-    def to_query(self, prefix: str = "") -> t.Tuple[str, t.Dict[str, t.Any]]:
+    def build(self, prefix: str = "") -> QueryResult:
         pass

--- a/edgegraph/expressions/side.py
+++ b/edgegraph/expressions/side.py
@@ -3,7 +3,7 @@ import typing as t
 from edgegraph.errors import ExpressionError
 from edgegraph.expressions.base import Expression
 from edgegraph.reflections import EdgeGraphField
-from edgegraph.types import PrimitiveTypes
+from edgegraph.types import PrimitiveTypes, QueryResult
 
 V = t.TypeVar("V")
 
@@ -30,7 +30,7 @@ class SideExpression(Expression, t.Generic[V]):
         self._origin_type = origin_type
         self._target_type = target_type
 
-    def to_query(self, prefix: str = "") -> t.Tuple[str, t.Dict[str, t.Any]]:
+    def build(self, prefix: str = "") -> QueryResult:
         result_dict: t.Dict[str, t.Any] = dict()
 
         if not (
@@ -49,7 +49,7 @@ class SideExpression(Expression, t.Generic[V]):
         elif isinstance(self._origin, EdgeGraphField):
             origin_query = f".{self._origin.name}"
         else:
-            (origin_query, update_dict) = self._origin.to_query()
+            (origin_query, update_dict) = self._origin.build()
             result_dict.update(update_dict)
             origin_query = f"({origin_query})"
 
@@ -64,9 +64,9 @@ class SideExpression(Expression, t.Generic[V]):
             target_query = f"<{self._target_type.value}>${target_key}"
             result_dict[target_key] = self._target
         else:
-            (target_query, update_dict) = self._target.to_query()
+            (target_query, update_dict) = self._target.build()
             result_dict.update(update_dict)
             target_query = f"({target_query})"
 
         result_query = f"{origin_query} {self._equation} {target_query}"
-        return result_query, result_dict
+        return QueryResult(result_query, result_dict)

--- a/edgegraph/query_builder/base.py
+++ b/edgegraph/query_builder/base.py
@@ -3,12 +3,10 @@ import typing as t
 from dataclasses import dataclass
 from enum import Enum
 
-from edgedb.abstract import QueryWithArgs
-
 from edgegraph.errors import ConditionValidationError
 from edgegraph.expressions.base import Expression
 from edgegraph.reflections import Configurable, EdgeGraphField
-from edgegraph.types import PrimitiveTypes
+from edgegraph.types import PrimitiveTypes, QueryResult
 
 T = t.TypeVar("T", bound=Configurable)
 
@@ -34,11 +32,7 @@ class QueryBuilderBase(t.Generic[T], metaclass=abc.ABCMeta):
         pass
 
     @abc.abstractmethod
-    def build(self, prefix: str = "") -> QueryWithArgs:
-        pass
-
-    @abc.abstractmethod
-    def build_string(self, prefix: str = "") -> str:
+    def build(self, prefix: str = "") -> QueryResult:
         pass
 
 

--- a/edgegraph/types.py
+++ b/edgegraph/types.py
@@ -1,4 +1,10 @@
+import typing as t
 from enum import Enum
+
+
+class QueryResult(t.NamedTuple):
+    query: str
+    kwargs: t.Dict[str, t.Any]
 
 
 class PrimitiveTypes(Enum):

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,6 +1,5 @@
 [mypy]
 plugins = pydantic.mypy
-ignore_missing_imports=True
 incremental=True
 warn_unused_ignores=True
 show_error_codes=True

--- a/poetry.lock
+++ b/poetry.lock
@@ -87,7 +87,7 @@ python-versions = ">=3.6.1"
 
 [[package]]
 name = "charset-normalizer"
-version = "2.1.0"
+version = "2.1.1"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
 category = "dev"
 optional = false
@@ -692,7 +692,10 @@ black = []
 bracex = []
 certifi = []
 cfgv = []
-charset-normalizer = []
+charset-normalizer = [
+    {file = "charset-normalizer-2.1.1.tar.gz", hash = "sha256:5a3d016c7c547f69d6f81fb0db9449ce888b418b5b9952cc5e6e66843e9dd845"},
+    {file = "charset_normalizer-2.1.1-py3-none-any.whl", hash = "sha256:83e9a75d1911279afd89352c68b45348559d1fc0506b054b346651b5e7fee29f"},
+]
 cibuildwheel = []
 click = []
 colorama = []

--- a/tests/query_builder/insert_test.py
+++ b/tests/query_builder/insert_test.py
@@ -106,7 +106,7 @@ def test_valid_insert_query_with_subquery_with_edgeql():
     # check subquery value contains
     result = False
     for key in memo_insert.kwargs.keys():
-        if key.startswith("equation_"):
+        if key.startswith("created_by__filter_") and "__equation_" in key:
             result = True
 
     assert result


### PR DESCRIPTION
Now EdgeGraph has new `edgegraph.types.QueryResult`. It is just a named tuple, and it contains query and keyword arguments. Every `Expressions` or `QueryBuilderBase[T]` must have `.build(self, prefix: str = "") -> QueryResult`. 

And this PR branch improve `SelectQueryBuilder`'s `.build_shape` pass new prefix to subquery or expression. 