### PR TITLE
Implement Update Query Builder

### DIFF
--- a/edgegraph/expressions/base.py
+++ b/edgegraph/expressions/base.py
@@ -1,13 +1,13 @@
 import abc
-import typing as t
 
 from edgegraph.types import QueryResult
 
-T = t.TypeVar("T")
 
-
-class Expression(t.Generic[T], metaclass=abc.ABCMeta):
-    base_cls: t.Type[T]
+class Expression(metaclass=abc.ABCMeta):
+    @property
+    @abc.abstractmethod
+    def type(self) -> str:
+        pass
 
     @abc.abstractmethod
     def build(self, prefix: str = "") -> QueryResult:

--- a/edgegraph/expressions/side.py
+++ b/edgegraph/expressions/side.py
@@ -9,7 +9,8 @@ V = t.TypeVar("V")
 
 
 class SideExpression(Expression, t.Generic[V]):
-    context = "equation"
+    type = "equation"
+
     _equation: str
     _origin: t.Union[V, EdgeGraphField, Expression]
     _target: t.Union[V, Expression]
@@ -24,6 +25,7 @@ class SideExpression(Expression, t.Generic[V]):
         origin_type: t.Optional[PrimitiveTypes] = None,
         target_type: t.Optional[PrimitiveTypes] = None,
     ):
+        super().__init__()
         self._equation = equation
         self._origin = origin
         self._target = target
@@ -39,10 +41,10 @@ class SideExpression(Expression, t.Generic[V]):
         ):
             if self._origin_type is None:
                 raise ExpressionError(
-                    self.context, f"Origin type is not defined for {self._origin}"
+                    self.type, f"Origin type is not defined for {self._origin}"
                 )
 
-            origin_key = f"{self.context}_{id(self._origin)}"
+            origin_key = f"{self.type}_{id(self._origin)}"
             origin_key = f"{prefix}__{origin_key}" if len(prefix) > 0 else origin_key
             origin_query = f"<{self._origin_type.name}>${origin_key}"
             result_dict[origin_key] = self._origin
@@ -56,10 +58,10 @@ class SideExpression(Expression, t.Generic[V]):
         if not isinstance(self._target, Expression):
             if self._target_type is None:
                 raise ExpressionError(
-                    self.context, f"Target type is not defined for {self._target}"
+                    self.type, f"Target type is not defined for {self._target}"
                 )
 
-            target_key = f"{self.context}_{id(self._target)}"
+            target_key = f"{self.type}_{id(self._target)}"
             target_key = f"{prefix}__{target_key}" if len(prefix) > 0 else target_key
             target_query = f"<{self._target_type.value}>${target_key}"
             result_dict[target_key] = self._target

--- a/edgegraph/query_builder/base.py
+++ b/edgegraph/query_builder/base.py
@@ -16,12 +16,12 @@ class QueryBuilderBase(Expression, t.Generic[T], metaclass=abc.ABCMeta):
         self.base_type = base_type
 
 
-class OrderEnum(Enum):
+class OrderType(Enum):
     ASC = "ASC"
     DESC = "DESC"
 
 
-class EmptyStrategyEnum(Enum):
+class EmptyStrategyType(Enum):
     FIRST = "FIRST"
     LAST = "LAST"
 
@@ -31,6 +31,12 @@ class QueryFieldType(Enum):
     SUBQUERY = "SUBQUERY"
     VALUE = "VALUE"
     NONE = "NONE"
+
+
+class AssignType(Enum):
+    ASSIGN = ":="
+    APPEND = "-="
+    REMOVE = "+="
 
 
 @dataclass(frozen=True)
@@ -50,9 +56,12 @@ class SelectQueryField(BaseQueryField[T]):
 
 
 @dataclass(frozen=True)
-class InsertQueryField(BaseQueryField[T]):
+class InsertOrUpdateQueryField(BaseQueryField[T]):
     edgedb_type: t.Optional[PrimitiveTypes] = None  # type represented on edgedb
     value: t.Optional[T] = None
+
+    # default is just 'assign', it can be 'append' or 'remove'
+    assign_type: AssignType = AssignType.ASSIGN
 
 
 def reference(

--- a/edgegraph/query_builder/insert.py
+++ b/edgegraph/query_builder/insert.py
@@ -4,7 +4,12 @@ from pydantic import BaseModel
 
 from edgegraph.errors import ConditionValidationError, QueryContextMissmatchError
 from edgegraph.expressions.base import Expression
-from edgegraph.query_builder.base import InsertQueryField, QueryBuilderBase, T
+from edgegraph.query_builder.base import (
+    InsertQueryField,
+    QueryBuilderBase,
+    QueryFieldType,
+    T,
+)
 from edgegraph.reflections import EdgeGraphField
 from edgegraph.types import PrimitiveTypes, QueryResult
 
@@ -12,10 +17,10 @@ V = t.TypeVar("V")
 
 
 class InsertQueryBuilder(QueryBuilderBase[T]):
-    query_type = "INSERT"
+    type = "INSERT"
 
     _unless_conflict: t.Optional[t.List[str]]
-    _unless_conflict_else: t.Optional[QueryBuilderBase]
+    _unless_conflict_else: t.Optional[QueryBuilderBase[T]]
     _fields: t.List[InsertQueryField]
 
     def __init__(self, cls: t.Type[T]):
@@ -28,9 +33,9 @@ class InsertQueryBuilder(QueryBuilderBase[T]):
         self,
         field: t.Union[EdgeGraphField[T, V], str],
         value: t.Optional[V] = None,
-        value_type: t.Optional[PrimitiveTypes] = None,
+        db_type: t.Optional[PrimitiveTypes] = None,
         expression: t.Optional[Expression] = None,
-        subquery: t.Optional[QueryBuilderBase] = None,
+        subquery: t.Optional[Expression] = None,
     ):
         # check if `value`, `expression`, `subquery` is all none
         if value is None and expression is None and subquery is None:
@@ -39,7 +44,7 @@ class InsertQueryBuilder(QueryBuilderBase[T]):
             )
 
         # check if `value` is available but, value_type is none
-        if value is not None and value_type is None:
+        if value is not None and db_type is None:
             raise ConditionValidationError(
                 str(field),
                 "You must specify `value_type` argument if you specify `value`.",
@@ -50,12 +55,12 @@ class InsertQueryBuilder(QueryBuilderBase[T]):
         if isinstance(field, str):
             field_name = field
             try:
-                field_info: EdgeGraphField = getattr(self.base_cls, "field_name")
+                field_info: EdgeGraphField = getattr(self.base_type, "field_name")
                 field_type = field_info.type
                 upper_type_name = field_info.base.__name__
             except AttributeError:
                 raise ConditionValidationError(
-                    field_name, f"Field does not exist in {self.base_cls}."
+                    field_name, f"Field does not exist in {self.base_type}."
                 )
         elif isinstance(field, EdgeGraphField):
             field_name = field.name
@@ -63,22 +68,22 @@ class InsertQueryBuilder(QueryBuilderBase[T]):
             upper_type_name = field.base.__name__
 
             try:
-                getattr(self.base_cls, field_name)
+                getattr(self.base_type, field_name)
             except AttributeError:
                 raise ConditionValidationError(
-                    field_name, f"Field does not exist in {self.base_cls}."
+                    field_name, f"Field does not exist in {self.base_type}."
                 )
         else:
             raise TypeError("field can be EdgeGraphField or str")
 
         # check field is available in this model
-        if upper_type_name != self.base_cls.__name__:
-            raise QueryContextMissmatchError(upper_type_name, self.base_cls)
+        if upper_type_name != self.base_type.__name__:
+            raise QueryContextMissmatchError(upper_type_name, self.base_type)
 
         # check field already exists.
         if field_name in [field.name for field in self._fields]:
             raise ConditionValidationError(
-                field_name, f"Field already exists in {self.base_cls}."
+                field_name, f"Field already exists in {self.base_type}."
             )
 
         # check field type is correct
@@ -90,14 +95,24 @@ class InsertQueryBuilder(QueryBuilderBase[T]):
                 f"Field type is not correct. Expected {field_type}, got {type(value)}",
             )
 
+        if value is not None:
+            query_field_type = QueryFieldType.VALUE
+            target_expression: t.Optional[Expression] = None
+        elif subquery is not None:
+            query_field_type = QueryFieldType.SUBQUERY
+            target_expression = subquery
+        else:
+            query_field_type = QueryFieldType.EXPRESSION
+            target_expression = expression
+
         self._fields.append(
             InsertQueryField(
                 name=field_name,
-                type=field_type,
+                query_field_type=query_field_type,
+                value_type=field_type,
                 upper_type_name=upper_type_name,
-                expression=expression,
-                subquery=subquery,
-                value_type=value_type,
+                expression=target_expression,
+                edgedb_type=db_type,
                 value=value,
             )
         )
@@ -107,7 +122,7 @@ class InsertQueryBuilder(QueryBuilderBase[T]):
     def unless_conflict(
         self,
         *fields: t.Union[str, EdgeGraphField],
-        else_query: QueryBuilderBase = None,
+        else_query: QueryBuilderBase[T] = None,
     ):
         # TODO(Hazealign): Check deep link fields when we support it.
         new_fields = []
@@ -132,7 +147,7 @@ class InsertQueryBuilder(QueryBuilderBase[T]):
 
     def build(self, prefix: str = "") -> QueryResult:
         # TODO(Hazealign): Check required fields are all settled.
-        (module, model_name) = self.base_cls.get_schema_config()
+        (module, model_name) = self.base_type.get_schema_config()
         result_args: t.Dict[str, t.Any] = dict()
         self._fields.sort(key=lambda x: x.name)
 
@@ -146,19 +161,19 @@ class InsertQueryBuilder(QueryBuilderBase[T]):
             if field.expression is not None:
                 expression = field.expression.build(context_prefix)
                 result_args.update(expression.kwargs)
-                query += f"{field.name}: {expression.query},\n"
 
-            elif field.subquery is not None:
-                subquery = field.subquery.build(context_prefix)
-                result_args.update(subquery.kwargs)
-                query += f"{field.name}: (\n{subquery.query}),\n"
+                if field.query_field_type == QueryFieldType.EXPRESSION:
+                    query += f"{field.name}: {expression.query},\n"
+                else:
+                    # Wrap Subquery
+                    query += f"{field.name}: (\n{expression.query}),\n"
 
             else:
                 # already we checked field.value_type before .add_field, but this expression is for type safety.
-                assert field.value_type is not None
+                assert field.edgedb_type is not None
                 key = f"{prefix}__{field.name}" if prefix != "" else field.name
                 result_args[key] = field.value
-                query += f"{field.name}: <{field.value_type.value}>${key},\n"
+                query += f"{field.name}: <{field.edgedb_type.value}>${key},\n"
 
         query += "}\n"
 

--- a/edgegraph/query_builder/select.py
+++ b/edgegraph/query_builder/select.py
@@ -4,8 +4,8 @@ from edgegraph.errors import ConditionValidationError, QueryContextMissmatchErro
 from edgegraph.expressions.base import Expression
 from edgegraph.query_builder.base import (
     BaseQueryField,
-    EmptyStrategyEnum,
-    OrderEnum,
+    EmptyStrategyType,
+    OrderType,
     QueryBuilderBase,
     QueryFieldType,
     SelectQueryField,
@@ -19,8 +19,8 @@ class SelectQueryBuilder(QueryBuilderBase[T]):
     type = "SELECT"
     _limit: t.Optional[int]
     _offset: t.Optional[int]
-    _order_by: t.Optional[t.Tuple[str, OrderEnum]]
-    _empty_strategy: t.Optional[EmptyStrategyEnum]
+    _order_by: t.Optional[t.Tuple[str, OrderType]]
+    _empty_strategy: t.Optional[EmptyStrategyType]
     _fields: t.List[SelectQueryField]
     _filters: t.List[Expression]
 
@@ -44,8 +44,8 @@ class SelectQueryBuilder(QueryBuilderBase[T]):
     def order(
         self,
         field: EdgeGraphField[T, t.Any],
-        order: OrderEnum,
-        empty: t.Optional[EmptyStrategyEnum] = None,
+        order: OrderType,
+        empty: t.Optional[EmptyStrategyType] = None,
     ):
         field_name = field.name
 
@@ -136,7 +136,7 @@ class SelectQueryBuilder(QueryBuilderBase[T]):
         self._fields.append(selection_field)
         return self
 
-    def filter(self, expr: Expression):
+    def add_filter(self, expr: Expression):
         if expr in self._filters:
             raise ConditionValidationError(str(expr), "Filter already exists.")
         self._filters.append(expr)

--- a/edgegraph/query_builder/update.py
+++ b/edgegraph/query_builder/update.py
@@ -123,6 +123,12 @@ class UpdateQueryBuilder(QueryBuilderBase[T]):
                 field_name, f"Field already exists in {self.base_type}."
             )
 
+        # check field_type is typing.Optional[T]
+        if t.get_origin(field_type) is t.Union and type(None) in t.get_args(field_type):
+            field_type = t.get_args(field_type)[0]
+
+        # TODO(Hazealign): if type is just and typing.Union[T] what shall we do?
+
         # check field type is correct
         if value is not None and (
             not isinstance(value, field_type) or isinstance(value, BaseModel)

--- a/edgegraph/schema.py
+++ b/edgegraph/schema.py
@@ -5,14 +5,11 @@ from pydantic import BaseModel
 from edgegraph.query_builder.base import SelectQueryField
 from edgegraph.query_builder.insert import InsertQueryBuilder
 from edgegraph.query_builder.select import SelectQueryBuilder
+from edgegraph.query_builder.update import UpdateQueryBuilder
 from edgegraph.reflections import Configurable, EdgeGraphField, EdgeMetaclass
 
 
 class EdgeModel(BaseModel, Configurable, metaclass=EdgeMetaclass):
-    # @classmethod
-    # def update(cls) -> UpdateQueryBuilder:
-    #     pass
-    #
     # @classmethod
     # def delete(cls) -> DeleteQueryBuilder:
     #     pass
@@ -35,3 +32,7 @@ class EdgeModel(BaseModel, Configurable, metaclass=EdgeMetaclass):
     @classmethod
     def insert(cls) -> InsertQueryBuilder:
         return InsertQueryBuilder(cls)
+
+    @classmethod
+    def update(cls) -> UpdateQueryBuilder:
+        return UpdateQueryBuilder(cls)

--- a/tests/query_builder/insert_test.py
+++ b/tests/query_builder/insert_test.py
@@ -56,9 +56,9 @@ def test_valid_insert_query_with_edgeql():
         dedent(
             """
                 insert default::Memo {
-                content: <str>$content,
-                created_at: <datetime>$created_at,
-                updated_at: <datetime>$updated_at,
+                content := <str>$content,
+                created_at := <datetime>$created_at,
+                updated_at := <datetime>$updated_at,
                 }
             """
         )[1:]
@@ -72,7 +72,7 @@ def test_valid_insert_query_with_subquery_with_edgeql():
 
     user_subquery = UserModel.select(
         [field(UserModel.id), field(UserModel.name)]
-    ).filter(
+    ).add_filter(
         SideExpression(
             equation="=",
             origin=field(UserModel.id),
@@ -108,7 +108,7 @@ def test_invalid_insert_query_parameter():
     UserModel = m.UserModel
     MemoModel = m.MemoModel
 
-    user_subquery = UserModel.select().filter(
+    user_subquery = UserModel.select().add_filter(
         SideExpression(
             equation="=",
             origin=field(UserModel.id),

--- a/tests/query_builder/insert_test.py
+++ b/tests/query_builder/insert_test.py
@@ -38,14 +38,10 @@ def test_valid_insert_query_with_edgeql():
         .add_field(
             field(MemoModel.content),
             value="Some Memo",
-            value_type=PrimitiveTypes.STRING,
+            db_type=PrimitiveTypes.STRING,
         )
-        .add_field(
-            field(MemoModel.created_at), date, value_type=PrimitiveTypes.DATETIME
-        )
-        .add_field(
-            field(MemoModel.updated_at), date, value_type=PrimitiveTypes.DATETIME
-        )
+        .add_field(field(MemoModel.created_at), date, db_type=PrimitiveTypes.DATETIME)
+        .add_field(field(MemoModel.updated_at), date, db_type=PrimitiveTypes.DATETIME)
         .build()
     )
 
@@ -91,15 +87,11 @@ def test_valid_insert_query_with_subquery_with_edgeql():
         .add_field(
             field(MemoModel.content),
             value="Some Memo",
-            value_type=PrimitiveTypes.STRING,
+            db_type=PrimitiveTypes.STRING,
         )
         .add_field(field(MemoModel.created_by), subquery=user_subquery)
-        .add_field(
-            field(MemoModel.created_at), date, value_type=PrimitiveTypes.DATETIME
-        )
-        .add_field(
-            field(MemoModel.updated_at), date, value_type=PrimitiveTypes.DATETIME
-        )
+        .add_field(field(MemoModel.created_at), date, db_type=PrimitiveTypes.DATETIME)
+        .add_field(field(MemoModel.updated_at), date, db_type=PrimitiveTypes.DATETIME)
         .build()
     )
 
@@ -131,7 +123,7 @@ def test_invalid_insert_query_parameter():
             .add_field(
                 field(MemoModel.content),
                 value="Some Memo",
-                value_type=PrimitiveTypes.STRING,
+                db_type=PrimitiveTypes.STRING,
             )
             .add_field(field(MemoModel.created_by), subquery=user_subquery)
             .add_field(field(MemoModel.created_at), pendulum.now())

--- a/tests/query_builder/select_test.py
+++ b/tests/query_builder/select_test.py
@@ -6,7 +6,7 @@ import pytest
 
 import tests.models as m
 from edgegraph.errors import QueryContextMissmatchError
-from edgegraph.query_builder.base import EmptyStrategyEnum, OrderEnum, reference
+from edgegraph.query_builder.base import EmptyStrategyType, OrderType, reference
 from edgegraph.reflections import field
 
 
@@ -44,7 +44,7 @@ def test_valid_select_query_with_edgeql():
         )
         .limit(10)
         .offset(0)
-        .order(MemoModel.created_at, OrderEnum.DESC, EmptyStrategyEnum.LAST)
+        .order(MemoModel.created_at, OrderType.DESC, EmptyStrategyType.LAST)
         .build()
     )
 
@@ -94,6 +94,6 @@ def test_invalid_fields_in_select_query():
             )
             .limit(10)
             .offset(0)
-            .order(MemoModel.created_at, OrderEnum.DESC, EmptyStrategyEnum.LAST)
+            .order(MemoModel.created_at, OrderType.DESC, EmptyStrategyType.LAST)
             .build()
         )

--- a/tests/query_builder/update_test.py
+++ b/tests/query_builder/update_test.py
@@ -1,0 +1,127 @@
+import asyncio
+import os
+from textwrap import dedent
+
+import pendulum
+import pytest
+
+import tests.models as m
+from edgegraph.expressions.side import SideExpression
+from edgegraph.reflections import field
+from edgegraph.types import PrimitiveTypes
+
+
+@pytest.fixture(scope="module")
+def event_loop():
+    loop = asyncio.new_event_loop()
+    yield loop
+    loop.close()
+
+
+@pytest.fixture()
+def edgedb_dsn():
+    dsn = os.getenv("EDGEDB_DSN")
+    if not dsn:
+        pytest.skip("Cannot test this test without EDGEDB_DSN environment variable.")
+
+    return dsn
+
+
+def test_valid_update_filter_query_with_edgeql():
+    MemoModel = m.MemoModel
+
+    memo_update = (
+        MemoModel.update()
+        .add_filter(
+            SideExpression(
+                equation="LIKE",
+                origin=field(MemoModel.content),
+                target="%테스트%",
+                target_type=PrimitiveTypes.STRING,
+            )
+        )
+        .add_field(field(MemoModel.deleted), db_type=PrimitiveTypes.BOOL, value=True)
+        .add_field(
+            field(MemoModel.deleted_at),
+            db_type=PrimitiveTypes.DATETIME,
+            value=pendulum.now(),
+        )
+        .build()
+    )
+
+    assert (
+        dedent(
+            """
+            set {
+            deleted := <bool>$deleted,
+            deleted_at := <datetime>$deleted_at,
+            }
+        """
+        )[1:]
+        in memo_update.query
+    )
+
+    assert "update default::Memo\n" in memo_update.query
+    assert "filter .content LIKE <str>$filter_" in memo_update.query
+
+    assert "deleted" in memo_update.kwargs
+    assert "deleted_at" in memo_update.kwargs
+
+
+def test_valid_update_subquery_query_with_edgeql():
+    MemoModel = m.MemoModel
+
+    memo_select_query = MemoModel.select(
+        [
+            field(MemoModel.id),
+            field(MemoModel.content),
+            field(MemoModel.deleted),
+            field(MemoModel.deleted_at),
+        ]
+    ).add_filter(
+        SideExpression(
+            equation="LIKE",
+            origin=field(MemoModel.content),
+            target="%테스트%",
+            target_type=PrimitiveTypes.STRING,
+        )
+    )
+
+    memo_update_query = (
+        MemoModel.update()
+        .set_target(memo_select_query)
+        .add_field(field(MemoModel.deleted), db_type=PrimitiveTypes.BOOL, value=True)
+        .add_field(
+            field(MemoModel.deleted_at),
+            db_type=PrimitiveTypes.DATETIME,
+            value=pendulum.now(),
+        )
+        .build()
+    )
+
+    assert memo_update_query.query.startswith(
+        dedent(
+            """
+                update (
+                select default::Memo {
+                content,
+                deleted,
+                deleted_at,
+                id,
+                }
+                filter .content LIKE <str>$target__filter_
+            """
+        )[1:-1]
+    )
+
+    assert memo_update_query.query.endswith(
+        dedent(
+            """
+                )
+                set {
+                deleted := <bool>$deleted,
+                deleted_at := <datetime>$deleted_at,
+                }
+            """
+        )[1:]
+    )


### PR DESCRIPTION
 - now querybuilder extends expression
 - expression has it's type property that has expression or query's name
 - expression has `build(self, prefix: str = "") -> QueryResult` method for build Query String and Keyword Arguments Dictionary
 - adding `QueryFieldType` for it is VALUE, SUBQUERY, EXPRESSION, or NONE
 - remove parameters which get subquery and expression both.
 - fix insert query builder for field assignment
 - introduce `AssignType` for update statements to append, remove or assign value or subquery / expression to field